### PR TITLE
Makefile: remove build -tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ check: install $(Check_Targets) ## Run tests and CI checks
 pedantic: check check-errcheck ## Run pedantic CI checks
 
 install: ## Build and install the contour binary
-	go install -mod=readonly -v -tags "oidc gcp" $(MODULE)/cmd/$(PROJECT)
+	go install -mod=readonly -v $(MODULE)/cmd/$(PROJECT)
 
 race:
-	go install -mod=readonly -v -race -tags "oidc gcp" $(MODULE)/cmd/$(PROJECT)
+	go install -mod=readonly -v $(MODULE)/cmd/$(PROJECT)
 
 download: ## Download Go modules
 	go mod download


### PR DESCRIPTION
In cmd/contour build tags are used to side effect import the gcp
authentication packages. This hack isn't needed in ir2proxy and we don't
have any files guarded by those build tags ...

Signed-off-by: Dave Cheney <dave@cheney.net>