### PR TITLE
Add support for nonroot IngressRoutes

### DIFF
--- a/hack/newtestcase
+++ b/hack/newtestcase
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+mkdir -p internal/$1/testdata/$2
+touch internal/$1/testdata/$2/input.yaml
+touch internal/$1/testdata/$2/output.yaml
+touch internal/$1/testdata/$2/errors.txt
+

--- a/internal/translator/testdata/nonroot-multiplematches/errors.txt
+++ b/internal/translator/testdata/nonroot-multiplematches/errors.txt
@@ -1,0 +1,1 @@
+The guess for the IngressRoute include path is /foo. HTTPProxy prefix conditions should not include the include prefix. Please check this value is correct. See https://projectcontour.io/docs/master/httpproxy/#conditions-and-inclusion

--- a/internal/translator/testdata/nonroot-multiplematches/input.yaml
+++ b/internal/translator/testdata/nonroot-multiplematches/input.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: nonroot-slash-match
+  namespace: default
+spec:
+  routes:
+    - match: /foo/bar
+      services:
+        - name: s1
+          port: 80
+    - match: /foo/baz
+      services:
+        - name: s1
+          port: 80

--- a/internal/translator/testdata/nonroot-multiplematches/output.yaml
+++ b/internal/translator/testdata/nonroot-multiplematches/output.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: nonroot-slash-match
+  namespace: default
+spec:
+  routes:
+  - conditions:
+    - prefix: /bar
+    services:
+    - name: s1
+      port: 80
+  - conditions:
+    - prefix: /baz
+    services:
+    - name: s1
+      port: 80
+status: {}

--- a/internal/translator/testdata/nonroot-singleslashmatch/input.yaml
+++ b/internal/translator/testdata/nonroot-singleslashmatch/input.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: nonroot-slash-match
+  namespace: default
+spec:
+  routes:
+    - match: /
+      services:
+        - name: s1
+          port: 80

--- a/internal/translator/testdata/nonroot-singleslashmatch/output.yaml
+++ b/internal/translator/testdata/nonroot-singleslashmatch/output.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: nonroot-slash-match
+  namespace: default
+spec:
+  routes:
+  - conditions:
+    - prefix: /
+    services:
+    - name: s1
+      port: 80
+status: {}

--- a/internal/translator/testdata/nonroot_ambiguous_prefix/errors.txt
+++ b/internal/translator/testdata/nonroot_ambiguous_prefix/errors.txt
@@ -1,0 +1,1 @@
+Can't determine include path from single match /foo/bar. HTTPProxy prefix conditions should not include the include prefix. Please check this value is correct. See https://projectcontour.io/docs/master/httpproxy/#conditions-and-inclusion

--- a/internal/translator/testdata/nonroot_ambiguous_prefix/input.yaml
+++ b/internal/translator/testdata/nonroot_ambiguous_prefix/input.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: nonroot-ambiguous-match
+  namespace: default
+spec:
+  routes:
+    - match: /foo/bar
+      services:
+        - name: s1
+          port: 80

--- a/internal/translator/testdata/nonroot_ambiguous_prefix/output.yaml
+++ b/internal/translator/testdata/nonroot_ambiguous_prefix/output.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: nonroot-ambiguous-match
+  namespace: default
+spec:
+  routes:
+  - conditions:
+    - prefix: /foo/bar
+    services:
+    - name: s1
+      port: 80
+status: {}


### PR DESCRIPTION
Fixes #19.

Next up is #25, which will put the warnings in the file where they belong.

Comments on my longestCommonPathPrefix thing welcomed.

Signed-off-by: Nick Young <ynick@vmware.com>